### PR TITLE
fix: remove redundant CI build after push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI Build Verification
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -48,4 +46,4 @@ jobs:
 
       - name: Build Verification of Docker Stack
         run: |
-          docker compose -f docker-compose.yaml build
+          docker compose -f docker-compose.yaml -f docker-compose.prod.yaml build

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,5 +1,5 @@
 # Production Overrides for FeastFinder Stack
-# Usage: docker compose -f docker-compose.yaml -f docker-compose.prod.yml up -d
+# Usage: docker compose -f docker-compose.yaml -f docker-compose.prod.yaml up -d
 
 x-logging: &default-logging
   driver: "json-file"
@@ -102,7 +102,7 @@ services:
   frontend:
     logging: *default-logging
     build:
-      context: ../frontend
+      context: ./frontend
       dockerfile: Dockerfile
     ports:
       - "8080:80"

--- a/start-prod.sh
+++ b/start-prod.sh
@@ -94,12 +94,12 @@ echo -e "\n${YELLOW}Step 3: Starting FeastFinder application services (Productio
 cd "$SCRIPT_DIR"
 
 echo "Attempting to pull pre-built production images from GHCR..."
-if docker compose -f docker-compose.yaml -f backend/docker-compose.prod.yml pull 2>/dev/null; then
+if docker compose -f docker-compose.yaml -f docker-compose.prod.yaml pull 2>/dev/null; then
     echo -e "${GREEN}Pre-built images pulled successfully from GHCR!${NC}"
-    docker compose -f docker-compose.yaml -f backend/docker-compose.prod.yml up -d
+    docker compose -f docker-compose.yaml -f docker-compose.prod.yaml up -d
 else
     echo -e "${YELLOW}GHCR images missing or unavailable — building services locally from source code...${NC}"
-    docker compose -f docker-compose.yaml -f backend/docker-compose.prod.yml up -d --build
+    docker compose -f docker-compose.yaml -f docker-compose.prod.yaml up -d --build
 fi
 
 echo -e "\n${GREEN}=========================================="

--- a/stop-prod.sh
+++ b/stop-prod.sh
@@ -22,7 +22,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Stop application services
 echo -e "\n${YELLOW}Stopping production application services...${NC}"
 cd "$SCRIPT_DIR"
-docker compose -f docker-compose.yaml -f backend/docker-compose.prod.yml down
+docker compose -f docker-compose.yaml -f docker-compose.prod.yaml down
 
 # Stop Supabase
 echo -e "\n${YELLOW}Stopping Supabase services...${NC}"


### PR DESCRIPTION
 Update to remove redundant CI build after push to main. This is because in release.yml already does the same build check + deploy image to ghcr.

Move prod docker compose yml to root folder for consistency.